### PR TITLE
Changing runner macos intel runner to macos-15-intel.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,8 +43,8 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        # using macos-13, last available intel architecture. macos-latest is arm64 architecture.
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        # using macos-15-intel, last available intel architecture. macos-latest is arm64 architecture.
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]
         inputs: ["00_ or 01_ or 02_ or 03_ or 04_ or 05_", "06_ or 07_ or 08_ or 09_ or 10_"]
     runs-on: ${{ matrix.os }}
     steps:
@@ -85,7 +85,7 @@ jobs:
       env: 
         SIMPLE_ITK_MEMORY_CONSTRAINED_ENVIRONMENT: 1
       run: | # pyenchant has a problem locating libenchant on macOS-ARM64. setting this environment variable resolves the issue
-        if [ "$RUNNER_OS" == "macOS" ] && [ "${{ matrix.os }}" != "macos-13" ]; then
+        if [ "$RUNNER_OS" == "macOS" ] && [ "${{ matrix.os }}" != "macos-15-intel" ]; then
            export PYENCHANT_LIBRARY_PATH=/opt/homebrew/lib/libenchant-2.dylib
         fi
         pytest -v --tb=short -k "${{matrix.inputs}}" tests/test_notebooks.py::Test_notebooks::test_python_notebook


### PR DESCRIPTION
The macos-13 runners are being deprecated as announced here: https://github.com/actions/runner-images/issues/13046

The replacement is macos-15-intel as announced here: https://github.com/actions/runner-images/issues/13045